### PR TITLE
Added dependency

### DIFF
--- a/xcrecord.rb
+++ b/xcrecord.rb
@@ -1,4 +1,5 @@
 class Xcrecord < Formula
+  depends_on "gifsicle" => :run
   desc "Capture gifs from the iOS simulator"
   homepage "https://github.com/klaaspieter/xcrecord"
   url "https://github.com/klaaspieter/xcrecord/archive/v1.0.0.tar.gz"


### PR DESCRIPTION
`gifsicle` is used when running the command but is not set as a dependency on the formulae.
Meaning that if the user doesn't have `gifsicle` installed it will fail:

```console
/usr/local/bin/xcrecord: line 19: gifsicle: command not found
```